### PR TITLE
:sparkles: allowing to pack objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.zip
 .DS_Store
+/refinex

--- a/coverage.md
+++ b/coverage.md
@@ -1,26 +1,88 @@
-## xgen-core/server/src/xplayer.lua
-*COVERAGE*: 20/21 (95.0%)
+## xgen-core\server\core.lua
+*COVERAGE*: 16/17 (94.0%)
 ```LUA
-40   |         error("Failed to update player last seen timestamp.")
+17   |         return players[player]
 ```
-## xgen-core/server/src/xaccount.lua
-*COVERAGE*: 58/62 (93.0%)
+## xgen-core\server\interface\xcharactersystem.lua
+*COVERAGE*: 5/8 (62.0%)
 ```LUA
-99   |         error("Failed to update account balance.")
-```
-```LUA
-146  |         error("Failed to update account balance.")
+13   |     error("startCharacterSelection function should be overwritten by the installed character selection system (external resource).")
 ```
 ```LUA
-197  |         error("Failed to create transaction.")
+21   |     error("startCreateNewCharacter function should be overwritten by the installed character creation system (external resource).")
 ```
 ```LUA
-228  |         table.insert(transactions, tx)
+28   |     error("onCharacterLoaded function should be overwritten by the installed character spawn system (external resource).")
 ```
-## xgen-charcreator/server/main.lua
-*COVERAGE*: 0/1 (0.0%)
+## xgen-core\server\src\xaccount.lua
+*COVERAGE*: 82/92 (89.0%)
 ```LUA
-7    |     print("Starting character creation for " .. xPlayer.identifier)
+101  |         self.balance_major = _major
+102  |         self.balance_minor = _minor
+103  |         error("Failed to update account balance.")
+```
+```LUA
+143  |         self.balance_major = self.balance_major - 1
+144  |         self.balance_minor = self.balance_minor + 100
+```
+```LUA
+148  |         self.balance_major = _major
+149  |         self.balance_minor = _minor
+150  |         error("Failed to update account balance.")
+```
+```LUA
+201  |         error("Failed to create transaction.")
+```
+```LUA
+232  |         table.insert(transactions, tx)
+```
+## xgen-core\server\src\xcharacter.lua
+*COVERAGE*: 25/26 (96.0%)
+```LUA
+45   |         error("Failed to create character: " .. instance.citizen_id .. "(citizen id already in use?)")
+```
+## xgen-core\server\src\xplayer.lua
+*COVERAGE*: 39/44 (88.0%)
+```LUA
+44   |         error("Failed to update player last seen timestamp.")
+```
+```LUA
+60   |         self.current_character.xPlayer = nil
+61   |         self.current_character = nil
+```
+```LUA
+65   |         return false
+```
+```LUA
+78   |         return
+```
+## xgen-core\server\src\xtransaction.lua
+*COVERAGE*: 25/26 (96.0%)
+```LUA
+39   |         error("Failed to create transaction: " .. instance.transaction_id .. "(transaction id already in use?)")
+```
+## xgen-core\server\util\dbsc.lua
+*COVERAGE*: 126/133 (94.0%)
+```LUA
+76   |             sql = sql .. " AUTO_INCREMENT"
+```
+```LUA
+116  |             goto continue
+```
+```LUA
+126  |             goto continue
+```
+```LUA
+137  |             goto continue
+```
+```LUA
+141  |         ::continue::
+```
+```LUA
+291  |         return true
+```
+```LUA
+307  |         return false
 ```
 
-Total coverage: 217/223 (97%)
+Total coverage: 419/447 (93%)

--- a/src/main/Content/Script/xgen-core/shared/pack.lua
+++ b/src/main/Content/Script/xgen-core/shared/pack.lua
@@ -1,0 +1,21 @@
+---@class Pack
+Pack = {}
+
+---Packs all the functions of the given class into the given object.
+---The object will also be returned for convenience (chaining).
+---Packing is required, when you want to make an object available for
+---outside resources, since metatables are not shared between
+---different resources.
+---@param obj table The object to pack the functions into.
+---@param clazz table The class containing the functions to pack.
+---@return table obj The object with the packed functions.
+function Pack.Pack(obj, clazz)
+    for k, v in pairs(clazz) do
+        if type(v) == "function" then
+            obj[k] = v
+        elseif type(v) == "table" and getmetatable(v) then
+            obj[k] = Pack.Pack(v, getmetatable(v))
+        end
+    end
+    return obj
+end

--- a/src/test/xgen-core/shared/pack.lua
+++ b/src/test/xgen-core/shared/pack.lua
@@ -1,0 +1,28 @@
+local Pack = ENVIRONMENT_GET_VAR(ENVIRONMENT, "Pack")
+
+Test.new('Pack should exist', function (self)
+    return Test.assert(Pack ~= nil, "Pack should not be nil")
+end)
+
+Test.new('Pack.Pack should pack functions from class to object', function (self)
+    local obj = { my_val = 42 }
+    local clazz = {
+        my_func = function(self) return self.my_val end,
+    }
+    Pack.Pack(obj, clazz)
+    return Test.assertEqual(obj:my_func(), 42, "Packed function should return correct value") and
+    Test.assertEqual(obj.my_val, 42, "Original value should remain unchanged")
+end)
+
+Test.new('Pack.Pack should handle nested tables with metatables', function (self)
+    local obj = {}
+    local nested = { nested_func = function(self) return "nested" end }
+    setmetatable(nested, nested)
+    local clazz = {
+        my_func = function(self) return "my_func" end,
+        nested_table = nested
+    }
+    Pack.Pack(obj, clazz)
+    return Test.assertEqual(obj:my_func(), "my_func", "Packed function should return correct value") and
+    Test.assertEqual(obj.nested_table:nested_func(), "nested", "Nested packed function should return correct value")
+end)

--- a/src/test/xgen-core/test.lua
+++ b/src/test/xgen-core/test.lua
@@ -1,5 +1,6 @@
 RFX_REQUIRE("src/test/xgen-core/shared/stringutils.lua")
 RFX_REQUIRE("src/test/xgen-core/shared/translator.lua")
+RFX_REQUIRE("src/test/xgen-core/shared/pack.lua")
 RFX_REQUIRE("src/test/xgen-core/server/util/dbsc.lua")
 RFX_REQUIRE("src/test/xgen-core/server/core.lua")
 RFX_REQUIRE("src/test/xgen-core/server/src/xcharactersystem.lua")

--- a/test.bat
+++ b/test.bat
@@ -1,1 +1,54 @@
-java -jar ..\RefineXModular\RefineX-1.0-SNAPSHOT.jar RFX ./test.lua
+@echo off
+setlocal
+
+REM === Einstellungen ===
+set DOWNLOAD_URL=https://github.com/java3east/RefineXModular/releases/download/latest/refinex.zip
+set ZIP_FILE=refinex.zip
+set EXTRACT_DIR=refinex
+set JAR_FILE=RefineX-1.0-SNAPSHOT.jar
+set LUA_SCRIPT=./test.lua
+
+REM === Argumente prüfen ===
+set KEEP=0
+if "%~1"=="--keep" set KEEP=1
+if "%~1"=="-k" set KEEP=1
+
+REM === Falls Ordner schon existiert ===
+if exist %EXTRACT_DIR% (
+    if %KEEP%==1 (
+        echo Folder "%EXTRACT_DIR%" already exists and will be kept.
+        echo Skipping download and extraction.
+        goto RUN_JAR
+    ) else (
+        echo Deleting old folder "%EXTRACT_DIR%"...
+        rmdir /s /q %EXTRACT_DIR%
+    )
+)
+
+echo [1/3] Downloading RefineX...
+curl -L -o %ZIP_FILE% %DOWNLOAD_URL%
+if errorlevel 1 (
+    echo Error downloading!
+    exit /b 1
+)
+
+echo [2/3] Extracting ZIP...
+powershell -command "Expand-Archive -Path '%ZIP_FILE%' -DestinationPath '%EXTRACT_DIR%' -Force"
+if errorlevel 1 (
+    echo Error extracting!
+    exit /b 1
+)
+
+:RUN_JAR
+echo [3/3] Starting JAR...
+java -jar "%EXTRACT_DIR%\%JAR_FILE%" RFX %LUA_SCRIPT%
+
+REM === Cleanup, wenn nicht behalten ===
+if %KEEP%==0 (
+    echo Cleaning up extracted folder...
+    rmdir /s /q %EXTRACT_DIR%
+) else (
+    echo Keeping extracted folder.
+)
+
+endlocal


### PR DESCRIPTION
This pull request introduces a new utility for packing class functions into objects to improve interoperability between resources. The main change is the addition of the `Pack` class and its `Pack.Pack` method, which allows functions from a class to be copied into a target object, ensuring functionality is preserved even when metatables are not shared.

New utility for function packing:

* Added a new `Pack` class in `src/main/Content/Script/xgen-core/shared/pack.lua` with a `Pack.Pack` method to copy all functions from a class into a given object, supporting chaining and recursive packing for nested tables with metatables.